### PR TITLE
Support markdown footnotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   KaTeX 0.13.5.  
   [John Fairhurst](https://github.com/johnfairh)
 
+* Support the markdown [footnotes](https://www.markdownguide.org/extended-syntax/#footnotes) extension in all themes.  
+  [John Fairhurst](https://github.com/johnfairh)
+  [#1246](https://github.com/realm/jazzy/issues/1246)
+
 ##### Bug Fixes
 
 * Fix parameter doc comments in Swft symbolgraph mode.  

--- a/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/apple/assets/css/jazzy.css.scss
@@ -23,7 +23,8 @@ $breadcrumb_padding_top: 17px;
 
 $code_font: 0.95em Menlo, monospace;
 
-$gray_border: 1px solid #e2e2e2;
+$gray_border_color: #e2e2e2;
+$gray_border: 1px solid $gray_border_color;
 $declaration_language_border: 5px solid #cde9f4;
 
 $aside_color: #aaa;
@@ -139,6 +140,25 @@ blockquote {
   margin-left: 0;
   padding: 0 10px;
   border-left: 4px solid #ccc;
+}
+
+// HRs
+
+hr {
+  height: 1px;
+  border: none;
+  background-color: $gray_border_color;
+}
+
+// Footnotes
+
+.footnote-ref {
+  display: inline-block;
+  scroll-margin-top: $content-top-offset;
+}
+
+.footnote-def {
+  scroll-margin-top: $content-top-offset;
 }
 
 // General Content Wrapper

--- a/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/fullwidth/assets/css/jazzy.css.scss
@@ -185,6 +185,11 @@ th, td {
   border: 1px solid $table_border_color;
 }
 
+hr {
+  height: 1px;
+  border: none;
+  background-color: $table_border_color;
+}
 
 // ----- Code
 

--- a/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
+++ b/lib/jazzy/themes/jony/assets/css/jazzy.css.scss
@@ -24,7 +24,8 @@ $breadcrumb_padding: 10px;
 
 $code_font: 'SF Mono', Menlo, monospace;
 
-$gray_border: 1px solid #e2e2e2;
+$gray_border_color: #e2e2e2;
+$gray_border: 1px solid $gray_border_color;
 $declaration_language_border: 5px solid #cde9f4;
 
 $aside_color: #aaa;
@@ -136,6 +137,25 @@ blockquote {
   margin-left: 0;
   padding: 0 10px;
   border-left: 4px solid #ccc;
+}
+
+// HRs
+
+hr {
+  height: 1px;
+  border: none;
+  background-color: $gray_border_color;
+}
+
+// Footnotes
+
+.footnote-ref {
+  display: inline-block;
+  scroll-margin-top: $content-top-offset;
+}
+
+.footnote-def {
+  scroll-margin-top: $content-top-offset;
 }
 
 // General Content Wrapper


### PR DESCRIPTION
* Enable the redcarpet feature
* Uniquify footnote links
* Adjust footnote links for fixed-header themes
* Adjust style of <hr> elements to match themes
* Add example to specs